### PR TITLE
Add white background color to PDF report (#1363)

### DIFF
--- a/templates/pdf/android_report.html
+++ b/templates/pdf/android_report.html
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="{{base_url}}{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   </head>
 
-  <body>
+  <body bgcolor="FFFFFF">
     <article id="cover">
       <div class="header">
         <img src="{{base_url}}{% static "img/mobsf_logo.png" %}" class="center logo" alt="MobSF Logo"/>

--- a/templates/pdf/ios_report.html
+++ b/templates/pdf/ios_report.html
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="{{base_url}}{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   </head>
 
-  <body>
+  <body bgcolor="FFFFFF">
     <article id="cover">
       <div class="header">
         <img src="{{base_url}}{% static "img/mobsf_logo.png" %}" class="center logo" alt="MobSF Logo"/>

--- a/templates/pdf/windows_report.html
+++ b/templates/pdf/windows_report.html
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="{{base_url}}{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   </head>
 
-  <body>
+  <body bgcolor="FFFFFF">
     <article id="cover">
       <div class="header">
         <img src="{{base_url}}{% static "img/mobsf_logo.png" %}" class="center logo" alt="MobSF Logo"/>


### PR DESCRIPTION
Set PDF background to white explicitly. OS with dark themes should not override this.

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`.
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
